### PR TITLE
Update get-involved.md

### DIFF
--- a/content/get-involved.md
+++ b/content/get-involved.md
@@ -8,19 +8,35 @@ description: Feeling inspired by Life Itself and itching to contribute to the se
 
 Feeling inspired by Life Itself and itching to contribute to the **second renaissance and a radically wiser, weller world**? You're in the right place! We're all about community, collaboration, and rolling up our sleeves to make a difference. So, if you've got some **time to spare and a heart of gold**, we'd love to have you on board!
 
+The first thing we'd suggest is that you **Join our "Get Involved" WhatsApp group:** It's your gateway to supporting **meaningful projects and tasks**. Think of it as a mission control center, buzzing with opportunities to lend a hand. When a task pops up, we'll send a quick message in the group. If it speaks to your skills and interests, simply hop in and let us know! We'll share all the necessary info and get you set up.
+
+
 <a href="https://chat.whatsapp.com/KxzvlRLFmMJ9WP32E9byRx" className="px-3 py-2 rounded no-underline	bg-secondary text-sm text-primary font-medium shadow-xs hover:bg-secondary/80 focus-visible:outline">Join the Get Involved Group on WhatsApp &raquo;</a>
 
 
 ![[../assets/images/community-page.jpg]]
 
-Here's the deal:
 
-* **Join our "Get Involved" WhatsApp group:** It's your gateway to supporting **meaningful projects and tasks**. Think of it as a mission control center, buzzing with opportunities to lend a hand.
-* **Simple, impactful tasks:** We won't throw you into the deep end. Tasks range from leaving a review on our Practical Action course to lending your creative spark to a social media post. Every little bit counts!
-* **No pressure, just good vibes:** When a task pops up, we'll send a quick message in the group. If it speaks to your skills and interests, simply hop in and let us know! We'll share all the necessary info and get you set up.
+## Things to dive into
 
-**Sound like fun? Join the "Get Involved" group and dive into the action!** Together, we can create a ripple effect of positive change, one small (but mighty) task at a time. See you there! 
+In addition to the Whatsapp group we have some ongoing activities you can dive right into.
 
-<a href="https://chat.whatsapp.com/KxzvlRLFmMJ9WP32E9byRx" className="px-3 py-2 rounded bg-secondary text-sm text-primary font-medium shadow-xs no-underline hover:bg-secondary/80 focus-visible:outline ">Join the Get Involved Group on WhatsApp &raquo;</a>
+**Wiki**
+
+The [Second Renaissance Wiki](https://wiki.secondrenaissance.net/wiki/Second_Renaissance_wiki) is a new initiative where we aim to provide useful, engaging and stimulating introductory material relating to the idea of a Second Renaissance. We’re very much looking for contributors to create and flesh out the initial entries and make this an amazing resource - check out the main page of the Wiki for guidance. Also look out for Wiki Club meetings and barnraising events for opportunities to work with others on this.
+
+**Forum**
+
+The [Second Renaissance Forum](https://forum.secondrenaissance.net/) is a new space for people to share ideas and explore paths to a second renaissance. We’re inspired by forums like LessWrong, which have done well in generating and spreading original ideas in an informal, collaborative and non-academic context. So long-form ‘blog’ style posts (including cross-posts from elsewhere) are especially welcome.
+
+**Help Get the Word Out** 
+
+- Boosting and Sharing posts and content on our newsletters [Life Itself](https://news.lifeitself.org/) and [Seeds of a Second Renaissance](https://news.secondrenaissance.net/) and our [Youtube channel](https://www.youtube.com/@bylifeitself)
+- Creating your own content that references Life Itself or Second Renaissance. Please do share it with us on the [Forum](https://forum.secondrenaissance.net/) or on [Whatsapp](https://chat.whatsapp.com/JNJCTZugNQn1fq89xbHtfA) (Events offers and Links group) when you do!
+- Contribute to our Second Renaissance Newsletter by suggesting items to include — such as events, jobs, articles and resources — in the the 'Events, Offers & Links' or 'Jobs Board' channels in our [WhatsApp community](https://chat.whatsapp.com/JNJCTZugNQn1fq89xbHtfA).
+
+**Join the Research Community**
+
+If you're a researcher at heart (and especially if you have a solid research background e.g. postgraduate degree) we’d love for you to contribute to original research as part of the research group. The best route into that is to attend the Life Itself Research calls (see the Life Itself [community calendar](https://lifeitself.org/community). Check our the [Research](https://lifeitself.org/research) page for more about what we're up to.
 
 **P.S.** Got questions? Don't hesitate to reach out! We're always happy to chat and share more about the exciting things we're working on. 


### PR DESCRIPTION
This commit proposes a number of updates to the get-involved page as part of #1157 (review of get involved guidance)

This may be subject to further changes later on, however for now the main point is to 
- remove the suggestion that tasks on the get involved whatsapp channel are mainly about boosting posts
- add 'things to dive right into' including the Wiki and the Forum in line with the previously reviewed Google doc text:  https://docs.google.com/document/d/1PsMd_BEvvd5d5Jxeofh9ph8oNm5DhoavIeSXtktEroI/edit?usp=sharing